### PR TITLE
Silence AWS configure

### DIFF
--- a/profile
+++ b/profile
@@ -127,9 +127,9 @@ function assume-role() {
 	# Reset the environment, or the awscli call will fail
   unset AWS_SESSION_TOKEN 
   unset AWS_SECURITY_TOKEN
-  export AWS_REGION=$(aws configure get region --profile $AWS_DEFAULT_PROFILE)
-  export AWS_ROLE_ARN=$(aws configure get role_arn --profile $AWS_DEFAULT_PROFILE)
-  export AWS_MFA_SERIAL=$(aws configure get mfa_serial --profile $AWS_DEFAULT_PROFILE)
+  export AWS_REGION=$(aws configure get region --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
+  export AWS_ROLE_ARN=$(aws configure get role_arn --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
+  export AWS_MFA_SERIAL=$(aws configure get mfa_serial --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
 
   if [ -z "$AWS_REGION" ]; then
     echo "region not set for $AWS_DEFAULT_PROFILE profile"


### PR DESCRIPTION
## what
* `/dev/null` stderr for `aws configure` commands

## why
* boto is obnoxious and spews a 20+ line stack trace

```
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/local/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 54, in main
    return driver.main()
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 186, in main
    command_table = self._get_command_table()
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 96, in _get_command_table
    self._command_table = self._build_command_table()
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 116, in _build_command_table
    command_object=self)
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/session.py", line 688, in emit
    return self._events.emit(event_name, **kwargs)
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/customizations/preview.py", line 70, in mark_as_preview
    service_name=original_command.service_model.service_name,
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 303, in service_model
    return self._get_service_model()
  File "/usr/local/aws/lib/python2.7/site-packages/awscli/clidriver.py", line 320, in _get_service_model
    api_version = self.session.get_config_variable('api_versions').get(
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/session.py", line 259, in get_config_variable
    elif self._found_in_config_file(methods, var_config):
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/session.py", line 280, in _found_in_config_file
    return var_config[0] in self.get_scoped_config()
  File "/usr/local/aws/lib/python2.7/site-packages/botocore/session.py", line 352, in get_scoped_config
    raise ProfileNotFound(profile=profile_name)
botocore.exceptions.ProfileNotFound: The config profile (cloudposs-ops) could not be found
```

## who
@cloudposse/engineering 