### PR TITLE
OS Portability & PS1 Prompt Width Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: default
 deps:
 	@which -s brew || (echo "Please install brew"; exit 1)
 	@which -s aws || brew install aws
+	@which -s jq || brew install jq
 
 ## Start a clean shell
 default:


### PR DESCRIPTION
## what
* Depending on OS, use appropriate commands & arguments
* Use brackets around ANSI colors in `PS1` so `bash` can calculate prompt-width

## why
* Different OS have same commands but with different arguments

## who
@cloudposse/engineering 