### PR TITLE
Check Profile Exists

### DIFF
--- a/profile
+++ b/profile
@@ -194,7 +194,7 @@ function assume-role() {
 
   aws configure list --profile ${AWS_DEFAULT_PROFILE} >/dev/null 2>&1
   if [ $? -ne 0 ]; then
-    echo "Profile for ${AWS_DEFAULT_PROFILE} not found"
+    echo "Profile for '${AWS_DEFAULT_PROFILE}' does not exist"
     return 1
   fi
 

--- a/profile
+++ b/profile
@@ -192,6 +192,12 @@ function assume-role() {
     return 1
   fi
 
+  aws configure list --profile ${AWS_DEFAULT_PROFILE} >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "Profile for ${AWS_DEFAULT_PROFILE} not found"
+    return 1
+  fi
+
   echo "Preparing to assume role associated with $AWS_DEFAULT_PROFILE"
   export AWS_PROFILE="$AWS_DEFAULT_PROFILE-session"
 


### PR DESCRIPTION
## what
* Check that an AWS profile exists before attempting to assume it

## why
* Better UX

## demo
```shell
[unsaved changes] (no assumed-role) ~> assume-role test
Profile for 'test' does not exist
```

## who
@goruha 