### PR TITLE
Exit zero when leaving the shell

### DIFF
--- a/profile
+++ b/profile
@@ -43,6 +43,7 @@ function prompt() {
 ## Display an exit greeting
 function _exit() {
   echo 'Goodbye'
+  exit 0
 }
 trap _exit EXIT
 


### PR DESCRIPTION
## what
* When leaving the shell, we should exit with a clean status code

## why
* used with `make` it appears like something went wrong, even though everything is cool

```bash
 ⧉ demo.dev.cloudposse.com
✅  (no assumed-role) ~ ➤ logout
Goodbye
make: *** [run] Error 130
```

## who
@goruha 