### PR TITLE
Fix re-assume-role

### DIFF
--- a/profile
+++ b/profile
@@ -59,6 +59,19 @@ function init() {
   fi
 }
 
+# Sync Docker VM's hardware clock which can drift when host machine sleeps
+#   e.g. An error occurred (SignatureDoesNotMatch) when calling the AssumeRole operation:
+#        Signature expired: 20170103T233357Z is now earlier than 20170104T042623Z (20170104T044123Z - 15 min.)
+function sync_hwclock() {
+  if [ -f "/.dockerenv" ]; then
+    hwclock -s 2>/dev/null
+    if [ $? -ne 0 ]; then
+      echo "WARNING: unable to sync system time from hardware clock; you may encounter problems with signed requests as a result of time drift."
+    fi
+  fi
+}
+
+
 ## Calculate the current shell prompt 
 function console-prompt() {
   NOW=$(date +%s)
@@ -201,10 +214,12 @@ function assume-role() {
     return 1
   fi
 
+  sync_hwclock
+
   echo "Preparing to assume role associated with $AWS_DEFAULT_PROFILE"
-  export AWS_PROFILE="$AWS_DEFAULT_PROFILE-session"
 
   # Reset the environment, or the awscli call will fail
+  unset AWS_PROFILE
   unset AWS_SESSION_TOKEN 
   unset AWS_SECURITY_TOKEN
   export AWS_REGION=$(aws configure get region --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
@@ -237,6 +252,7 @@ function assume-role() {
 
   TMP_FILE=$(find $HOME/.aws/cli/cache -name "${AWS_DEFAULT_PROFILE}*.json" | head -1)
   if [ -f "$TMP_FILE" ]; then
+    export AWS_PROFILE="$AWS_DEFAULT_PROFILE-session"
     export AWS_ACCESS_KEY_ID=$(cat ${TMP_FILE} | jq -r ".Credentials.AccessKeyId")
     export AWS_SECRET_ACCESS_KEY=$(cat ${TMP_FILE} | jq -r ".Credentials.SecretAccessKey")
     export AWS_SESSION_TOKEN=$(cat ${TMP_FILE} | jq -r ".Credentials.SessionToken")

--- a/profile
+++ b/profile
@@ -179,20 +179,19 @@ function leave-role() {
     find $HOME/.aws/cli/cache -name "${AWS_DEFAULT_PROFILE}*.json" -delete
   fi
 
-  if [ -n "${AWS_PROFILE}" ] || [ -n "${AWS_DEFAULT_PROFILE}" ]; then
-    unset AWS_DEFAULT_PROFILE
-    unset AWS_ACCESS_KEY_ID
-    unset AWS_SECRET_ACCESS_KEY
-    unset AWS_SESSION_TOKEN 
-    unset AWS_SECURITY_TOKEN
-    unset AWS_IAM_MFA_SERIAL
-    unset AWS_IAM_ROLE_ARN
-    unset AWS_REGION
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_SESSION_TOKEN 
+  unset AWS_SECURITY_TOKEN
+  unset AWS_IAM_MFA_SERIAL
+  unset AWS_IAM_ROLE_ARN
+  unset AWS_REGION
+  unset AWS_DEFAULT_PROFILE
 
+  if [ -n "${AWS_PROFILE}" ]; then
     # wipe out temporary session
     update_profile
     unset AWS_PROFILE
-
   else
     echo "No role currently assumed"
   fi
@@ -208,6 +207,13 @@ function assume-role() {
     return 1
   fi
 
+  # Reset the environment, or the awscli call will fail
+  unset AWS_PROFILE
+  unset AWS_SESSION_TOKEN 
+  unset AWS_SECURITY_TOKEN
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+
   aws configure list --profile ${AWS_DEFAULT_PROFILE} >/dev/null 2>&1
   if [ $? -ne 0 ]; then
     echo "Profile for '${AWS_DEFAULT_PROFILE}' does not exist"
@@ -218,10 +224,6 @@ function assume-role() {
 
   echo "Preparing to assume role associated with $AWS_DEFAULT_PROFILE"
 
-  # Reset the environment, or the awscli call will fail
-  unset AWS_PROFILE
-  unset AWS_SESSION_TOKEN 
-  unset AWS_SECURITY_TOKEN
   export AWS_REGION=$(aws configure get region --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
   export AWS_IAM_ROLE_ARN=$(aws configure get role_arn --profile $AWS_DEFAULT_PROFILE 2>/dev/null)
   export AWS_IAM_MFA_SERIAL=$(aws configure get mfa_serial --profile $AWS_DEFAULT_PROFILE 2>/dev/null)


### PR DESCRIPTION
## what
* Always attempt to sync the hardware clock if `/.dockerenv` present 
* Unset `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_ID` before attempting to assume role
* Always unset environment variables on `leave-role`

## why
* When laptop goes to sleep, the `docker` time can drift making it impossible to sign AWS requests
* If the `AWS_` env are present, they take precedence over the AWS profile which makes it impossible to re-assume a role without first calling `leave-role` (which was a nuisance) 

## who
@goruha 