### PR TITLE
Fix really bad time drift

### DIFF
--- a/profile
+++ b/profile
@@ -67,9 +67,10 @@ function init() {
 function sync_hwclock() {
   if [ -f "/.dockerenv" ]; then
     if [ -n "${NTP_SERVER}" ] && [ -n "${NTPD}" ]; then
-    ${NTPD} -d -q -n -p "${NTP_SERVER}" 
-    if [ $? -ne 0 ]; then
-      echo "WARNING: unable to sync time; requests might fail due to time drift"
+      ${NTPD} -d -q -n -p "${NTP_SERVER}" 
+      if [ $? -ne 0 ]; then
+        echo "WARNING: unable to sync time; requests might fail due to time drift in docker"
+      fi
     fi
   fi
 }

--- a/profile
+++ b/profile
@@ -68,7 +68,7 @@ function sync_hwclock() {
   if [ -f "/.dockerenv" ]; then
     if [ -n "${NTP_SERVER}" ] && [ -n "${NTPD}" ]; then
       echo "Synchronizing clock..."
-      ${NTPD} -d -q -n -p "${NTP_SERVER}" >/dev/null
+      ${NTPD} -d -q -n -p "${NTP_SERVER}" >/dev/null 2>&1
       if [ $? -ne 0 ]; then
         echo "WARNING: unable to sync time; requests might fail due to time drift in docker"
       fi

--- a/profile
+++ b/profile
@@ -6,6 +6,8 @@ ERROR_COLOR="\033[31;01m"
 PROMPT_COLOR="\033[01m"
 
 export AWS_SESSION_DURATION=3600
+export NTP_SERVER=${NTP_SERVER:-pool.ntp.org}
+export NTPD=$(which ntpd)
 
 which jq >/dev/null || (echo "Missing required 'jq' dependency"; exit 1)
 
@@ -64,13 +66,13 @@ function init() {
 #        Signature expired: 20170103T233357Z is now earlier than 20170104T042623Z (20170104T044123Z - 15 min.)
 function sync_hwclock() {
   if [ -f "/.dockerenv" ]; then
-    hwclock -s 2>/dev/null
+    if [ -n "${NTP_SERVER}" ] && [ -n "${NTPD}" ]; then
+    ${NTPD} -d -q -n -p "${NTP_SERVER}" 
     if [ $? -ne 0 ]; then
-      echo "WARNING: unable to sync system time from hardware clock; you may encounter problems with signed requests as a result of time drift."
+      echo "WARNING: unable to sync time; requests might fail due to time drift"
     fi
   fi
 }
-
 
 ## Calculate the current shell prompt 
 function console-prompt() {

--- a/profile
+++ b/profile
@@ -67,7 +67,8 @@ function init() {
 function sync_hwclock() {
   if [ -f "/.dockerenv" ]; then
     if [ -n "${NTP_SERVER}" ] && [ -n "${NTPD}" ]; then
-      ${NTPD} -d -q -n -p "${NTP_SERVER}" 
+      echo "Synchronizing clock..."
+      ${NTPD} -d -q -n -p "${NTP_SERVER}" >/dev/null
       if [ $? -ne 0 ]; then
         echo "WARNING: unable to sync time; requests might fail due to time drift in docker"
       fi


### PR DESCRIPTION
## what
* call `ntpd` to sync system time

## why
* sync'ing with the hardware clock is apparently not enough - hardware clock might also be out of sync
  Symptoms look like this:
   ```shell
   (no assumed-role) ~> assume-role cloudposse-ops
   Enter MFA code: 
   Profile for 'cloudposse-ops' does not exist
   ```
## who
@goruha 