### PR TITLE
Fix profile check

### DIFF
--- a/profile
+++ b/profile
@@ -218,7 +218,12 @@ function assume-role() {
   unset AWS_ACCESS_KEY_ID
   unset AWS_SECRET_ACCESS_KEY
 
-  aws configure list --profile ${AWS_DEFAULT_PROFILE} >/dev/null 2>&1
+  if [ ! -f "${AWS_CONFIG_FILE}" ]; then
+    echo "AWS Configuration does not exist. Run \`setup-role\` or \`aws configure\`."
+    exit 1
+  fi
+
+  grep -q "\[profile ${AWS_DEFAULT_PROFILE}\]" "${AWS_CONFIG_FILE}"
   if [ $? -ne 0 ]; then
     echo "Profile for '${AWS_DEFAULT_PROFILE}' does not exist"
     return 1

--- a/profile
+++ b/profile
@@ -64,7 +64,7 @@ function init() {
 # Sync Docker VM's hardware clock which can drift when host machine sleeps
 #   e.g. An error occurred (SignatureDoesNotMatch) when calling the AssumeRole operation:
 #        Signature expired: 20170103T233357Z is now earlier than 20170104T042623Z (20170104T044123Z - 15 min.)
-function sync_hwclock() {
+function sync_clock() {
   if [ -f "/.dockerenv" ]; then
     if [ -n "${NTP_SERVER}" ] && [ -n "${NTPD}" ]; then
       echo "Synchronizing clock..."
@@ -229,7 +229,7 @@ function assume-role() {
     return 1
   fi
 
-  sync_hwclock
+  sync_clock
 
   echo "Preparing to assume role associated with $AWS_DEFAULT_PROFILE"
 


### PR DESCRIPTION
## what
* use `grep` to check if profile exists
* rename `sync_hwclock` to `sync_clock` 

## why
* `aws configure list` constantly prompts for MFA code which makes it useless for this kind of validation
* we no longer sync from `hwclock` so renamed function to just `sync_clock`

## who
@goruha 